### PR TITLE
初步优化取数据算法, 取数时当余量不足再发起请求

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,38 +17,39 @@ export default async function* mixLoader(iterators, sortFn, pickNumber) {
     let dataSet = [];
     // 需要请求的迭代器列表
     let activeIterators = iterators.slice();
+    // 每个迭代器返回的数据中还未显示的数量
+    let unpickCount = Array(iterators.length).fill(0);
 
     // 还有迭代器可以请求时
     while (activeIterators.length > 0) {
-        // 所有迭代器请求一次
-        const reqs = activeIterators.map(iter => iter.next());
+        // 所有已返回数据余量不足pickNumber的迭代器请求一次
+        const reqs = activeIterators.map((iter, idx) => unpickCount[idx] < pickNumber ? iter.next() : { value: [], done: false });
         let res = await Promise.all(reqs);
 
         for (let i = 0; i < res.length; i++) {
             let {value, done} = res[i];
             console.log(value, done);
-            // 如果该迭代器迭代完了，就从迭代器列表中移除
-            if (done) {
-                activeIterators.splice(i, 1);
+            // 如果该迭代器未迭代完，将请求到的数组，合并到结果中
+            if (!done) {
+                dataSet = dataSet.concat(value.map(val => ({val, i})));
+                unpickCount[i] += value.length; 
             }
-            // 否则，将请求到的数组，合并到结果中
-            else {
-                dataSet = dataSet.concat(value);
+            // 否则，当数据余量为0时, 将其迭代器和余量计数从数组中移除
+            else if (unpickCount[i] === 0){
+                activeIterators.splice(i, 1);
+                unpickCount.splice(i, 1);
             }
         }
 
         // 对结果排序
-        dataSet.sort(sortFn);
+        dataSet.sort((a, b) => sortFn(a.val, b.val));
 
         // 从结果中取出 pickNumber 个数据
         console.log(dataSet);
-        yield dataSet.splice(0, pickNumber);
-    }
-
-    // 所有异步数据都请求完毕后，结果数组有剩余，则不发请求，直接从结果数组中取数据即可
-    while (dataSet.length > 0) {
-        console.log(dataSet);
-        yield dataSet.splice(0, pickNumber);
+        yield dataSet.splice(0, pickNumber).map(data => {
+            --unpickCount[data.i];
+            return data.val;
+        });
     }
 
 }

--- a/test/test.js
+++ b/test/test.js
@@ -29,7 +29,7 @@ async function* getRepoIssue(path) {
 function sorter(a, b) {
     const valueA = (new Date(a.updated_at)).getTime();
     const valueB = (new Date(b.updated_at)).getTime();
-    return valueA - valueB;
+    return valueB - valueA;
 }
 
 // 合并两个异步迭代器


### PR DESCRIPTION
基础版调整, 对每个迭代器已返回, 但未取出的数据余量进行计数, 取数时当余量不足再发起请求.
测试中排序改为倒序.

目前mixLoader还默认pickNumber与api每页返回数据条数一致, 未来需要调整.